### PR TITLE
vagrant workflow updates

### DIFF
--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -7,7 +7,7 @@ Vagrant.configure('2') do |config|
     provisioner.vm.box = 'generic/ubuntu1804'
     provisioner.vm.hostname = 'provisioner'
     provisioner.vm.synced_folder '.', '/vagrant', type: 'rsync'
-    provisioner.vm.provision :shell, path: 'tinkerbell.sh', args: [$provisioner_ip_address]
+    provisioner.vm.provision :shell, path: './scripts/tinkerbell.sh'
 
     provisioner.vm.provider :libvirt do |lv, override|
       lv.memory = 2*1024

--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -1,4 +1,3 @@
-$provisioner_ip_address = '10.11.12.2'
 ENV['VAGRANT_NO_PARALLEL'] = 'yes'
 
 Vagrant.configure('2') do |config|
@@ -29,7 +28,12 @@ Vagrant.configure('2') do |config|
 
   config.vm.define "worker" do |worker|
     worker.vm.box = nil
-    worker.vm.network "private_network", ip: $provisioner_ip_address, mac: "080027000001", auto_config: false
+    worker.vm.network :private_network,
+                      mac: "080027000001",
+                      virtualbox__intnet: "tink_network",
+                      libvirt__dhcp_enabled: false,
+                      libvirt__forward_mode: 'none',
+                      auto_config: false
 
     worker.vm.provider :libvirt do |lv|
       lv.memory = 1*1024

--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -9,23 +9,21 @@ Vagrant.configure('2') do |config|
     provisioner.vm.synced_folder './../../', '/vagrant'
     provisioner.vm.provision :shell, path: './scripts/tinkerbell.sh'
 
+    provisioner.vm.network :private_network,
+                        virtualbox__intnet: "tink_network",
+                        libvirt__dhcp_enabled: false,
+                        libvirt__forward_mode: 'none',
+                        auto_config: false
+
     provisioner.vm.provider :libvirt do |lv, override|
       lv.memory = 2*1024
       lv.cpus = 2
       lv.cpu_mode = 'host-passthrough'
-      override.vm.network "private_network",
-        ip: $provisioner_ip_address,
-        libvirt__dhcp_enabled: false,
-        libvirt__forward_mode: 'none'
     end
 
     provisioner.vm.provider :virtualbox do |vb, override|
       vb.memory = 2*1024
       vb.cpus = 2
-      override.vm.network "private_network",
-                          virtualbox_intnet: "tink_network",
-                          auto_config: false
-
     end
   end
 

--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -6,7 +6,7 @@ Vagrant.configure('2') do |config|
   config.vm.define :provisioner do |provisioner|
     provisioner.vm.box = 'generic/ubuntu1804'
     provisioner.vm.hostname = 'provisioner'
-    provisioner.vm.synced_folder './../../', '/vagrant', type: 'rsync'
+    provisioner.vm.synced_folder './../../', '/vagrant'
     provisioner.vm.provision :shell, path: './scripts/tinkerbell.sh'
 
     provisioner.vm.provider :libvirt do |lv, override|

--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -22,7 +22,10 @@ Vagrant.configure('2') do |config|
     provisioner.vm.provider :virtualbox do |vb, override|
       vb.memory = 2*1024
       vb.cpus = 2
-      override.vm.network "private_network", ip: $provisioner_ip_address
+      override.vm.network "private_network",
+                          virtualbox_intnet: "tink_network",
+                          auto_config: false
+
     end
   end
 

--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -6,7 +6,7 @@ Vagrant.configure('2') do |config|
   config.vm.define :provisioner do |provisioner|
     provisioner.vm.box = 'generic/ubuntu1804'
     provisioner.vm.hostname = 'provisioner'
-    provisioner.vm.synced_folder '.', '/vagrant', type: 'rsync'
+    provisioner.vm.synced_folder './../../', '/vagrant', type: 'rsync'
     provisioner.vm.provision :shell, path: './scripts/tinkerbell.sh'
 
     provisioner.vm.provider :libvirt do |lv, override|

--- a/deploy/vagrant/scripts/tinkerbell.sh
+++ b/deploy/vagrant/scripts/tinkerbell.sh
@@ -58,13 +58,6 @@ command_exists() (
 	command -v "$@" >/dev/null 2>&1
 )
 
-mirror_hello_world() (
-	# push the hello-world workflow action image
-	docker pull hello-world
-	docker tag hello-world "$TINKERBELL_HOST_IP/hello-world"
-	docker push "$TINKERBELL_HOST_IP/hello-world"
-)
-
 main() (
 	export DEBIAN_FRONTEND=noninteractive
 
@@ -93,11 +86,6 @@ main() (
 	./setup.sh
 
 	secure_certs
-
-	mirror_hello_world
-
-	cd deploy
-	docker-compose up -d
 )
 
 main

--- a/deploy/vagrant/scripts/tinkerbell.sh
+++ b/deploy/vagrant/scripts/tinkerbell.sh
@@ -54,6 +54,15 @@ command_exists() (
 	command -v "$@" >/dev/null 2>&1
 )
 
+configure_vagrant_user() (
+	sudo usermod -aG docker vagrant
+
+	echo -n "$TINKERBELL_REGISTRY_PASSWORD" \
+		| sudo -iu vagrant docker login \
+		       --username="$TINKERBELL_REGISTRY_USERNAME" \
+		       --password-stdin "$TINKERBELL_HOST_IP"
+)
+
 main() (
 	export DEBIAN_FRONTEND=noninteractive
 
@@ -83,7 +92,8 @@ main() (
 
 	secure_certs
 
-       	sudo usermod -aG docker vagrant
+	configure_vagrant_user
+
 )
 
 main

--- a/deploy/vagrant/scripts/tinkerbell.sh
+++ b/deploy/vagrant/scripts/tinkerbell.sh
@@ -28,10 +28,6 @@ setup_docker() (
 
 	sudo apt-get update
 	sudo apt-get install -y docker-ce docker-ce-cli containerd.io
-
-       	sudo usermod -aG docker "$USER"
-
-	newgrp
 )
 
 setup_docker_compose() (
@@ -86,6 +82,8 @@ main() (
 	./setup.sh
 
 	secure_certs
+
+       	sudo usermod -aG docker vagrant
 )
 
 main

--- a/setup.sh
+++ b/setup.sh
@@ -251,7 +251,7 @@ setup_osie() (
 
 	local osie_current=$STATEDIR/webroot/misc/osie/current
 	local tink_workflow=$STATEDIR/webroot/workflow/
-	if [ ! -d "$osie_current" ] && [ ! -d "$tink_workflow" ]; then
+	if [ ! -d "$osie_current" ] || [ ! -d "$tink_workflow" ]; then
 		mkdir -p "$osie_current"
 		mkdir -p "$tink_workflow"
 		pushd "$SCRATCH"


### PR DESCRIPTION
on this branch I was able to do this:

```

[nix-shell:~/projects/github.com/tinkerbell/tink/deploy/vagrant]$ vagrant up --provider=virtualbox provisioner
[nix-shell:~/projects/github.com/tinkerbell/tink/deploy/vagrant]$ vagrant ssh provisioner
vagrant@provisioner:~$ cd /deploy
-bash: cd: /deploy: No such file or directory
vagrant@provisioner:~$ ^C
vagrant@provisioner:~$ cd /vagrant/
vagrant@provisioner:/vagrant$ cat > hello-world.yml
version: "0.1"
name: hello_world_workflow
global_timeout: 600
tasks:
  - name: "hello world"
    worker: "{{.device_1}}"
    actions:
      - name: "hello_world"
        image: hello-world
        timeout: 60
vagrant@provisioner:/vagrant$ cat > hardware-data.json
{
  "id": "ce2e62ed-826f-4485-a39f-a82bb74338e2",
  "arch": "x86_64",
  "allow_pxe": true,
  "allow_workflow": true,
  "facility_code": "onprem",
  "ip_addresses": [
    {
      "address": "192.168.1.5",
      "address_family": 4,
      "enabled": true,
      "gateway": "192.168.1.1",
      "management": true,
      "netmask": "255.255.255.248",
      "public": false
    }
  ],
  "network_ports": [
    {
      "data": {
        "mac": "08:00:27:00:00:01"
      },
      "name": "eth0",
      "type": "data"
    }
  ]
}
vagrant@provisioner:/vagrant$
vagrant@provisioner:/vagrant$ cd deploy/
vagrant@provisioner:/vagrant/deploy$ . ../envrc
vagrant@provisioner:/vagrant/deploy$ docker-compose up -d
vagrant@provisioner:/vagrant/deploy$ docker exec -i deploy_tink-cli_1 tink template create --name hello-world < ../hello-world.yml
Created Template:  de0bcbee-6958-4367-a433-d83146db8317
vagrant@provisioner:/vagrant/deploy$ docker exec -i deploy_tink-cli_1 tink hardware push < ../hardware-data.json
2020/06/16 13:42:36 Hardware data pushed successfully
vagrant@provisioner:/vagrant/deploy$ docker exec -i deploy_tink-cli_1 tink workflow create -t de0bcbee-6958-4367-a433-d83146db8317 -r '{"device_1":"08:00:27:00:00:01"}'
Created Workflow:  c58f1a9a-5a1f-4dd8-8db8-11cf6576c87b
vagrant@provisioner:/vagrant/deploy$ docker-compose logs -f
[nix-shell:~/projects/github.com/tinkerbell/tink/deploy/vagrant]$ vagrant up --provider=virtualbox worker
```

